### PR TITLE
Handle files with spaces in names

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = function ebookConvert (args, options, callback) {
       return callback(new Error(msg))
     }
     args = toFlags(args).join(' ')
-    var cmd = 'ebook-convert ' + input + ' ' + output + ' ' + args
+    var cmd = `ebook-convert "${input}" "${output}" ${args}`
     exec(cmd, options, callback)
   })
 }


### PR DESCRIPTION
Fixes a bug where filenames containing spaces in filenames weren't being converted.